### PR TITLE
Config Tweaks

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,5 @@
 [
-  import_deps: [:ecto, :phoenix],
+  import_deps: [:phoenix],
   inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],
   subdirectories: ["priv/*/migrations"]
 ]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.9.1
+elixir 1.9.1-otp-22
 erlang 22.0.7
 nodejs 12.6.0


### PR DESCRIPTION
Why:

* We should be using the elixir version compiled with the same version
  of erlang we're using.
* The formatter was broken due to importing ecto which is no longer
  available.

This change addresses the need by:

* Add the erlang prefix to the asdf tool version for elixir.
* Remove ecto from the formatter import.

Side effects:

* People will need to install the newer version of elixir if they
  haven't already.