### PR TITLE
Server-initiated game updates

### DIFF
--- a/lib/typo_kart/game_master.ex
+++ b/lib/typo_kart/game_master.ex
@@ -84,7 +84,8 @@ defmodule TypoKart.GameMaster do
   end
 
   def handle_call({:end_game, game_id}, _from, state) do
-    with %Game{state: :running, players: players} = game <- Kernel.get_in(state, [:games, game_id]),
+    with %Game{state: :running, players: players} = game <-
+           Kernel.get_in(state, [:games, game_id]),
          updated_game <- Map.put(game, :state, :ended),
          updated_state <- put_in(state, [:games, game_id], updated_game) do
       Enum.map(players, fn
@@ -94,6 +95,7 @@ defmodule TypoKart.GameMaster do
         %Player{view_pid: view_pid} ->
           send(view_pid, :end_game)
       end)
+
       {:reply, {:ok, updated_game}, updated_state}
     else
       nil ->
@@ -218,7 +220,8 @@ defmodule TypoKart.GameMaster do
   end
 
   @spec register_player_view(binary(), integer(), pid()) :: {:ok, Game.t()} | {:error, binary()}
-  def register_player_view(game_id, player_index, pid) when is_integer(player_index) and is_pid(pid) do
+  def register_player_view(game_id, player_index, pid)
+      when is_integer(player_index) and is_pid(pid) do
     GenServer.call(__MODULE__, {:register_player_view, game_id, player_index, pid})
   end
 
@@ -493,14 +496,14 @@ defmodule TypoKart.GameMaster do
   # Handle rounding without using floats
   def time_remaining(%Game{end_time: end_time}) do
     with end_time_ms <- DateTime.to_unix(end_time, :millisecond),
-      now_ms <- Util.now_unix(:millisecond),
-      diff_ms <- end_time_ms - now_ms,
-      floored <- Integer.floor_div(diff_ms, 1000) do
-        if Integer.mod(diff_ms, 1000) >= 500 do
-          floored + 1
-        else
-          floored
-        end
+         now_ms <- Util.now_unix(:millisecond),
+         diff_ms <- end_time_ms - now_ms,
+         floored <- Integer.floor_div(diff_ms, 1000) do
+      if Integer.mod(diff_ms, 1000) >= 500 do
+        floored + 1
+      else
+        floored
+      end
     end
   end
 

--- a/lib/typo_kart/game_master.ex
+++ b/lib/typo_kart/game_master.ex
@@ -490,9 +490,18 @@ defmodule TypoKart.GameMaster do
   def time_remaining(%Game{state: :ended}), do: 0
   def time_remaining(%Game{state: :pending}), do: 0
 
+  # Handle rounding without using floats
   def time_remaining(%Game{end_time: end_time}) do
-    DateTime.to_unix(end_time) -
-      DateTime.to_unix(Util.now())
+    with end_time_ms <- DateTime.to_unix(end_time, :millisecond),
+      now_ms <- Util.now_unix(:millisecond),
+      diff_ms <- end_time_ms - now_ms,
+      floored <- Integer.floor_div(diff_ms, 1000) do
+        if Integer.mod(diff_ms, 1000) >= 500 do
+          floored + 1
+        else
+          floored
+        end
+    end
   end
 
   defp unowned_class, do: "unowned"

--- a/lib/typo_kart/game_master.ex
+++ b/lib/typo_kart/game_master.ex
@@ -6,7 +6,8 @@ defmodule TypoKart.GameMaster do
     Course,
     Path,
     PathCharIndex,
-    Player
+    Player,
+    Util
   }
 
   @player_count_limit 3
@@ -55,7 +56,7 @@ defmodule TypoKart.GameMaster do
 
   def handle_call({:start_game, game_id}, _from, state) do
     with %Game{players: players} = game <- Kernel.get_in(state, [:games, game_id]),
-         now <- DateTime.utc_now() |> DateTime.truncate(:second),
+         now <- Util.now(),
          end_time <- DateTime.add(now, @game_run_duration_seconds, :second),
          updated_game <- game |> Map.put(:state, :running) |> Map.put(:end_time, end_time),
          updated_state <- put_in(state, [:games, game_id], updated_game) do
@@ -491,7 +492,7 @@ defmodule TypoKart.GameMaster do
 
   def time_remaining(%Game{end_time: end_time}) do
     DateTime.to_unix(end_time) -
-      DateTime.to_unix(DateTime.utc_now() |> DateTime.truncate(:second))
+      DateTime.to_unix(Util.now())
   end
 
   defp unowned_class, do: "unowned"

--- a/lib/typo_kart/player.ex
+++ b/lib/typo_kart/player.ex
@@ -5,6 +5,7 @@ defmodule TypoKart.Player do
             color: "",
             label: "",
             points: 0,
+            view_pid: nil,
             cur_path_char_indices: [%PathCharIndex{}]
 
   @type t :: %__MODULE__{
@@ -12,6 +13,7 @@ defmodule TypoKart.Player do
           color: binary(),
           label: binary(),
           points: integer(),
+          view_pid: nil | pid(),
           cur_path_char_indices: list(PathCharIndex.t())
         }
 end

--- a/lib/typo_kart/util.ex
+++ b/lib/typo_kart/util.ex
@@ -1,8 +1,16 @@
 defmodule TypoKart.Util do
-  @doc "DateTime.utc_now() wth :second truncation"
-  @spec now() :: DateTime.t()
-  def now do
+  @doc "DateTime.utc_now() with the given precision: :second by default"
+  @spec now(atom()) :: DateTime.t()
+  def now(precision \\ :second) do
     DateTime.utc_now()
-    |> DateTime.truncate(:second)
+    |> DateTime.truncate(precision)
+  end
+
+  @doc "DateTime.utc_now() through to_unix with the given precision: :second by default"
+  @spec now(atom()) :: DateTime.t()
+  def now_unix(precision \\ :second) do
+    DateTime.utc_now()
+    |> DateTime.truncate(precision)
+    |> DateTime.to_unix(precision)
   end
 end

--- a/lib/typo_kart/util.ex
+++ b/lib/typo_kart/util.ex
@@ -1,0 +1,8 @@
+defmodule TypoKart.Util do
+  @doc "DateTime.utc_now() wth :second truncation"
+  @spec now() :: DateTime.t()
+  def now do
+    DateTime.utc_now()
+    |> DateTime.truncate(:second)
+  end
+end

--- a/lib/typo_kart_web/live/race_live.ex
+++ b/lib/typo_kart_web/live/race_live.ex
@@ -74,7 +74,8 @@ defmodule TypoKartWeb.RaceLive do
     # and again when the websocket is mounted.
     # We can test whether it's the latter case with connected?(socket)
 
-    if connected?(socket), do: :timer.send_interval(@game_update_auto_interval_ms, self(), :update_game)
+    if connected?(socket),
+      do: :timer.send_interval(@game_update_auto_interval_ms, self(), :update_game)
 
     with %Game{} = game <- game_with_current_player_view(game_id, player_index) do
       {
@@ -156,21 +157,31 @@ defmodule TypoKartWeb.RaceLive do
 
   def handle_event(_, _, socket), do: {:noreply, socket}
 
-  def handle_info(:end_game, %{
+  def handle_info(
+        :end_game,
+        %{
           assigns: %{
             game_id: game_id
-          }} = socket
-  ) do
+          }
+        } = socket
+      ) do
     {:noreply, assign(socket, game: GameMaster.state() |> get_in([:games, game_id]))}
   end
 
-  def handle_info(:update_game, %{
+  def handle_info(
+        :update_game,
+        %{
           assigns: %{
             game_id: game_id
-          }} = socket
-  ) do
+          }
+        } = socket
+      ) do
     if should_update_game?(socket) do
-      {:noreply, assign(socket, last_game_update: Util.now_unix(:millisecond), game: GameMaster.state() |> get_in([:games, game_id]))}
+      {:noreply,
+       assign(socket,
+         last_game_update: Util.now_unix(:millisecond),
+         game: GameMaster.state() |> get_in([:games, game_id])
+       )}
     else
       {:noreply, socket}
     end
@@ -178,7 +189,8 @@ defmodule TypoKartWeb.RaceLive do
 
   def handle_info(_, _, socket), do: {:noreply, socket}
 
-  defp game_with_current_player_view(game_id, player_index) when is_binary(game_id) and is_integer(player_index) do
+  defp game_with_current_player_view(game_id, player_index)
+       when is_binary(game_id) and is_integer(player_index) do
     with {:ok, %Game{} = game} <- GameMaster.register_player_view(game_id, player_index, self()) do
       game
     else
@@ -188,6 +200,6 @@ defmodule TypoKartWeb.RaceLive do
   end
 
   defp should_update_game?(%{assigns: %{last_game_update: last_game_update}}) do
-    (Util.now_unix(:millisecond) - last_game_update) >= @game_update_rate_limit_ms
+    Util.now_unix(:millisecond) - last_game_update >= @game_update_rate_limit_ms
   end
 end

--- a/lib/typo_kart_web/templates/race/error.html.leex
+++ b/lib/typo_kart_web/templates/race/error.html.leex
@@ -1,0 +1,8 @@
+<div class="error-container">
+<p>
+Whoops, there's been some error.
+</p>
+<p>
+<%= link "Head back to the lobby", to: "/" %>
+</p>
+</div>

--- a/lib/typo_kart_web/templates/race/game_end.html.leex
+++ b/lib/typo_kart_web/templates/race/game_end.html.leex
@@ -1,0 +1,4 @@
+<div class="game-end-container">
+<h1>Game Over</h1>
+<%= link "Go back", to: "/" %>
+</div>

--- a/lib/typo_kart_web/templates/race/index.html.leex
+++ b/lib/typo_kart_web/templates/race/index.html.leex
@@ -1,8 +1,8 @@
 <div id="game-info">
-<p>Time Remaining: <%= game_timer_formatted(@game) %> </p>
-<%= for {player, player_index} <- Enum.with_index(@game.players, 1) do %>
-<p><span class="<%= player.color %>">Player <%= player_index %> points:</span><span><%= player.points %></span></p>
-<% end %>
+  <p>Time Remaining: <%= game_timer_formatted(@game, @last_game_update) %> </p>
+  <%= for {player, player_index} <- Enum.with_index(@game.players, 1) do %>
+  <p><span class="<%= player.color %>">Player <%= player_index %> points:</span><span><%= player.points %></span></p>
+  <% end %>
 </div>
 <div id="the-course" class="<%= @error_status %>" phx-keyup="key" phx-target="window" phx-hook="CurrentText">
   <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="<%= @game.course.view_box %>">

--- a/lib/typo_kart_web/views/race_view.ex
+++ b/lib/typo_kart_web/views/race_view.ex
@@ -136,8 +136,12 @@ defmodule TypoKartWeb.RaceView do
     |> Enum.join(" ")
   end
 
-  @spec game_timer_formatted(Game.t()) :: binary()
-  def game_timer_formatted(%Game{} = game) do
+  @doc """
+  A second argument may be passed for its side-effect of triggering an update
+  of this helper's rendering into a template when that argument's value changes.
+  """
+  @spec game_timer_formatted(Game.t(), integer()) :: binary()
+  def game_timer_formatted(%Game{} = game, _ \\ 0) do
     with total_seconds <- GameMaster.time_remaining(game),
          minutes <- Integer.floor_div(total_seconds, 60),
          seconds <- Integer.mod(total_seconds, 60),

--- a/test/typo_kart/game_master_test.exs
+++ b/test/typo_kart/game_master_test.exs
@@ -1269,4 +1269,26 @@ defmodule TypoKart.GameMasterTest do
     assert {:ok, _} = GameMaster.end_game(game_id)
     assert {:error, _} = GameMaster.end_game(game_id)
   end
+
+  @tag :register_player_view
+  test "regiser_player_view/2" do
+    game_id = GameMaster.new_game()
+    assert {:ok, _game, %Player{view_pid: nil}} = GameMaster.add_player(game_id)
+    assert {:ok, %Game{players: [%Player{view_pid: pid} | _rest]}} = GameMaster.register_player_view(game_id, 0, self())
+    assert self() == pid
+  end
+
+  @tag :register_player_view
+  test "regiser_player_view/2 when player is invalid" do
+    game_id = GameMaster.new_game()
+    assert {:ok, _game, %Player{view_pid: nil}} = GameMaster.add_player(game_id)
+    assert {:error, _} = GameMaster.register_player_view(game_id, 1, self())
+  end
+
+  @tag :register_player_view
+  test "regiser_player_view/2 when game_id is invalid" do
+    game_id = GameMaster.new_game()
+    assert {:ok, _game, %Player{view_pid: nil}} = GameMaster.add_player(game_id)
+    assert {:error, _} = GameMaster.register_player_view("x#{game_id}", 0, self())
+  end
 end

--- a/test/typo_kart/game_master_test.exs
+++ b/test/typo_kart/game_master_test.exs
@@ -1274,7 +1274,10 @@ defmodule TypoKart.GameMasterTest do
   test "regiser_player_view/2" do
     game_id = GameMaster.new_game()
     assert {:ok, _game, %Player{view_pid: nil}} = GameMaster.add_player(game_id)
-    assert {:ok, %Game{players: [%Player{view_pid: pid} | _rest]}} = GameMaster.register_player_view(game_id, 0, self())
+
+    assert {:ok, %Game{players: [%Player{view_pid: pid} | _rest]}} =
+             GameMaster.register_player_view(game_id, 0, self())
+
     assert self() == pid
   end
 


### PR DESCRIPTION
This PR addresses:

1. The scheduling and trigger of the end_game event when the game timer expires.
2. Triggering updates on the player views as the game state changes, up to some rate limiting
3. Scheduling an update to occur at least every second (keeps the gamer ticking, and updating opponent's activities, even if the current user is less active)